### PR TITLE
Devtools hotkeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "css-loader": "^0.28.7",
     "electron": "2.0.10",
     "electron-builder": "^20.8.1",
+    "electron-debug": "2.0.0",
     "electron-mocha": "^5.0.0",
     "electron-react-devtools": "^0.5.3",
     "electron-rebuild": "^1.7.3",

--- a/src/main.js
+++ b/src/main.js
@@ -56,7 +56,7 @@ function createWindow() {
 
     //loading window gracefully
     win.once('ready-to-show', () => {
-	win.maximize();
+        win.maximize();
         win.show();
     });
 
@@ -65,10 +65,10 @@ function createWindow() {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-	win = null;
-	if (process.platform !== 'darwin') {
-	    app.quit();
-	}
+        win = null;
+        if (process.platform !== 'darwin') {
+            app.quit();
+        }
     });
 }
 
@@ -77,35 +77,35 @@ var dbSetup = new Promise(
     if ( !existsSync('db') ) {
       mkdirSync( 'db' );
     }
-	// Setup database.
-	var dbUtil = require(`${__dirname}/util/DbUtil.js`);
-	dbUtil.setupTargetDb
-	    .then((response) => {
-		console.log(response);
-		return dbUtil.setupRefDb;
-	    })
-	    .then((response) => {
-		console.log(response);
+        // Setup database.
+        var dbUtil = require(`${__dirname}/util/DbUtil.js`);
+        dbUtil.setupTargetDb
+            .then((response) => {
+                console.log(response);
+                return dbUtil.setupRefDb;
+            })
+            .then((response) => {
+                console.log(response);
         return dbUtil.setupLookupsDb;
-	    })
+            })
         .then((response)=>{
             console.log(response)
             resolve(response)
         })
         .catch((err) => {
-		console.log('Error while DB setup. ' + err);
-		reject(err);
-	    });
+                console.log('Error while DB setup. ' + err);
+                reject(err);
+            });
     });
 
 function preProcess() {
     dbSetup
-	.then((response) => {
-	    createWindow();
-	})
-	.catch((err) => {
-	    console.log('Error while App intialization.' + err);
-	});
+        .then((response) => {
+            createWindow();
+        })
+        .catch((err) => {
+            console.log('Error while App intialization.' + err);
+        });
 }
 
 // This method will be called when Electron has finished

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,14 @@ import {existsSync, mkdirSync} from 'fs'
 // be closed automatically when the JavaScript object is garbage collected.
 let win;
 
+// Allow F12 or Ctrl-Shift-I to open Chrome Dev Tools when in development mode.
+if (env.name === "development") {
+    require('electron-debug')({
+        showDevTools: false,
+        devToolsMode: "previous"
+    });
+}
+
 function createWindow() {
     // Create the browser window.
     win = new BrowserWindow({
@@ -30,10 +38,7 @@ function createWindow() {
     'webPreferences': {'session': session},
     show: false
     });
-    if (env.name === "development") {
-        //win.openDevTools();
-    }
-    
+
     // and load the index.html of the app.
     // win.loadURL(`file:${__dirname}/views/index.html`);
     win.setMenu(null);
@@ -51,8 +56,6 @@ function createWindow() {
 
     //loading window gracefully
     win.once('ready-to-show', () => {
-	// Open the DevTools.
-	//win.webContents.openDevTools();	
 	win.maximize();
         win.show();
     });
@@ -105,9 +108,6 @@ function preProcess() {
 	});
 }
 
-// if (env.name === "development") {
-//     win.openDevTools();
-//   }
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
@@ -129,8 +129,6 @@ app.on('activate', () => {
     if (win === null) {
     createWindow();
     }
-    // win.openDevTools();
-    
 });
 
 //code for sigle instance at a time according to electron 3.0.0


### PR DESCRIPTION
Instead of uncommenting debugging code, enable developer tools via [Chrome hotkeys](https://developers.google.com/web/tools/chrome-devtools/shortcuts).  Implemented by [electron-debug](https://github.com/sindresorhus/electron-debug).  This is only enabled during Electron development mode, and the library is not included in release builds.

Also correct a few stray tab characters.