### PR TITLE
Update maximum permitted length of bible name

### DIFF
--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -466,7 +466,7 @@ class SettingsModal extends React.Component {
     // this.setState({bibleReference: !this.state.bibleReference});
     const currentTrans = AutographaStore.currentTrans;
     let bibleNameLen = this.state.refName.length;
-    if( bibleNameLen >= 10 ){
+    if( bibleNameLen > 10 ){
       swal(currentTrans["label-bible-name"], currentTrans["ref_name_max_valid"], "error")
       return
     }


### PR DESCRIPTION
Documentation suggests that the maximum length should be 10 characters, and this limit seems to be fairly arbitrary(?). This PR updates the maximum allowed length from 9 to 10 characters, as suggested by the documentation, and should close #8