### PR TITLE
issue60 resolved

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -249,7 +249,7 @@ class Navbar extends React.Component {
     }
 
     onItemClick(bookName) {
-        
+        this.goToTab(2)
         AutographaStore.bookName = bookName;
         AutographaStore.chapterActive = 0;
         
@@ -696,7 +696,7 @@ class Navbar extends React.Component {
                                 </div>
                                  ) : ''
                             }
-                            <Tab eventKey={1} title="Book" onClick={() => this.goToTab(2)}>
+                            <Tab eventKey={1} title="Book">
                                 <div className="wrap-center"></div>
                                 <div className="row books-li" id="bookdata">
                                     <ul id="books-pane">


### PR DESCRIPTION
HI,
I've solved the following issue which was mentioned and I have also run the test with successful result.

In the book-chapter selector, it is noticed that when you click on the white region between the book names, takes you in to the chapter section. The ideal behavior is that it should only progress in to the chapter section only if a book is actually clicked.

Please, have a look at the pull request