### PR TITLE
Update dependencies so macOS builds work again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "sweetalert-react": "^0.4.11",
     "tmp": "0.0.33",
     "transform-runtime": "0.0.0",
-    "wacs-client": "0.1.0",
+    "wacs-client": "0.1.1",
     "webpack": "^4.5.0",
     "xml2js": "^0.4.19"
   },


### PR DESCRIPTION
Down the dependency tree, we need an SSL lib that macOS doesn't include anymore, so let's update. See https://github.com/nodegit/nodegit/issues/1200#issuecomment-426834982