### PR TITLE
Fix e2e script name so pree2e runs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "preunit": "webpack --config=build/webpack.unit.config.js --env=test --display=none",
     "unit": "electron-mocha tests/test.js --renderer --require source-map-support/register",
     "pree2e": "webpack --config=build/webpack.app.config.js --env=test --display=none && webpack --config=build/webpack.e2e.config.js --env=test --display=none",
-    "tests": "mocha --timeout 50000 tests/test.js --require source-map-support/register",
-    "test": "yarn tests",
+    "e2e": "mocha --timeout 50000 tests/test.js --require source-map-support/register",
+    "test": "yarn run e2e",
     "start": "node build/start.js",
     "release": "webpack --config=build/webpack.app.config.js --env=production && electron-builder"
   },


### PR DESCRIPTION
This is the simplest fix. If the "tests" name is preferred over "e2e"
then the pree2e script should be renamed also, and probably so should
the file build/webpack.e2e.config.js so everything matches.