### PR TITLE
Paratext sync upload fix

### DIFF
--- a/src/components/ProjectListRow.js
+++ b/src/components/ProjectListRow.js
@@ -443,12 +443,20 @@ class ProjectListRow extends React.Component {
 												verseCount = dbContent.length;
 												v = v + 1; 
 											} else {
-												currVerse.nextSibling.remove();
-												currVerse.remove();
+												if (currVerse.nextSibling) {
+													currVerse.nextSibling.remove();
+												}
+												if (currVerse) {
+													currVerse.remove();
+												}
 											}
 										} else {
-											currVerse.nextSibling.remove();
-											currVerse.remove();
+											if (currVerse.nextSibling) {
+												currVerse.nextSibling.remove();
+											}
+											if (currVerse) {
+												currVerse.remove();
+											}
 										}
 									}
 								}


### PR DESCRIPTION
While trying to upload the joined verses without any content to Paratext was throwing an _error_. 
Fixed the issue by avoiding the removal of **null** nodes.

_Error_ - **null** can't be removed.