### PR TITLE
Fixed the issue by initializing the verse number to zero

### DIFF
--- a/src/util/usfm_to_json.js
+++ b/src/util/usfm_to_json.js
@@ -56,7 +56,8 @@ module.exports = {
                     "chapter": parseInt(splitLine[1], 10)
                 }
                 verse = [];
-                c = parseInt(splitLine[1], 10)
+                c = parseInt(splitLine[1], 10);
+                vnum = 0;
                 v = 0;
             } else if (splitLine[0] === '\\v') {
                 if (c === 0)


### PR DESCRIPTION
Fixed issue #129  by initializing the vnum=0 on every new chapter.
To avoid the special tags with content between chapter tag (\c) and verse 1 tag (\v 1).