### PR TITLE
Auto-backup not working on windows

### DIFF
--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -110,7 +110,14 @@ class SettingsModal extends React.Component {
 			console.log(err);
 		})
 		this.loadSetting();
-	}
+    }
+    
+    componentDidUpdate(){
+        const {langCode, langVersion, backupFrequency} = this.state.settingData;
+        if (langCode && langVersion && backupFrequency !== "none") {
+            auto_export.initializeBackUp();
+        }
+    }
 
 	loadSetting = () => {
 		const settingData = this.state.settingData;
@@ -247,15 +254,15 @@ class SettingsModal extends React.Component {
 
 	saveSetting = () => {
 		if (this.target_setting() === false) return;
-    const currentTrans = AutographaStore.currentTrans;
+        const currentTrans = AutographaStore.currentTrans;
 		const {langCode, langVersion, folderPath, backupFrequency} = this.state.settingData;
 		const settingData = { 
 		_id: 'targetBible',
 		targetLang: langCode.toLowerCase(),
 		targetVersion: langVersion,
 		targetPath: folderPath,
-    langScript: AutographaStore.scriptDirection.toUpperCase(),
-    backupFrequency: backupFrequency
+        langScript: AutographaStore.scriptDirection.toUpperCase(),
+        backupFrequency: backupFrequency
 		}
 		db.get('targetBible').then((doc) => {
 		settingData._rev = doc._rev;

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1106,7 +1106,7 @@ class SettingsModal extends React.Component {
                           <FormattedMessage id="label-auto-backup" />
                           </label>
                           <RadioButtonGroup
-                            valueSelected={backupFrequency}
+                            valueSelected={backupFrequency === "" ? "daily" : backupFrequency}
                             name="autobackup"
                             style={{display: "flex", marginBottom:"6%", marginTop: "8px"}}
                             onChange={(event, value) => this.onChangeBackupSetting(value)}

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -276,10 +276,6 @@ class SettingsModal extends React.Component {
 			swal(currentTrans["dynamic-msg-trans-data"], currentTrans["dynamic-msg-went-wrong"], "success");
 		});
     });
-
-    if (langCode && langVersion && backupFrequency !== "none") {
-      auto_export.initializeBackUp();
-    }
 	}
 
 	openFileDialogSettingData = (event) => {

--- a/src/util/auto_export.js
+++ b/src/util/auto_export.js
@@ -163,13 +163,13 @@ function getTimeStamp(date) {
         minute = (date.getMinutes() < 10 ? '0' : '') + date.getMinutes(),
         second = (date.getSeconds() < 10 ? '0' : '') + date.getSeconds();
 
-    return (months[parseInt(month)-1] + " " + day + "-" + year.toString() + "_" + hour + ":" + minute + ":" + second).toString();
+    return (months[parseInt(month)-1] + " " + day + "-" + year.toString() + "_" + hour + "" + minute + "" + second).toString();
 }
 
 function calculateDays(currDate, preDate) 
  {
-    var currTime = new Date(currDate[0] + " " + currDate[1]);
-    var preTime = new Date(preDate[0] + " " + preDate[1]);
+    var currTime = new Date(currDate[0] + " " + currDate[1].toString().replace(/\B(?=(\d{2})+(?!\d))/g, ":"));
+    var preTime = new Date(preDate[0] + " " + preDate[1].toString().replace(/\B(?=(\d{2})+(?!\d))/g, ":"));
     var difference = Math.abs(currTime.getTime() - preTime.getTime()) / 1000;
     // var hour = Math.floor(difference / 3600) % 24;
     // var minutes = Math.floor(difference / 60) % 60;

--- a/src/util/auto_export.js
+++ b/src/util/auto_export.js
@@ -37,7 +37,6 @@ async function backUp() {
             let timeStamp = [ d && getTimeStamp(d) ].filter(Boolean);
             let currentTime = timeStamp[0].split('_');
             let days = calculateDays(currentTime,folderName);
-            console.log(targetLangDoc.backupFrequency)
             if (days >= 1 && (targetLangDoc.backupFrequency).toLowerCase() === "daily") {
                 buildFilePath(new Date(), dirPath);
                 folderHandling (folders, dirPath);

--- a/src/util/auto_export.js
+++ b/src/util/auto_export.js
@@ -37,6 +37,7 @@ async function backUp() {
             let timeStamp = [ d && getTimeStamp(d) ].filter(Boolean);
             let currentTime = timeStamp[0].split('_');
             let days = calculateDays(currentTime,folderName);
+            console.log(targetLangDoc.backupFrequency)
             if (days >= 1 && (targetLangDoc.backupFrequency).toLowerCase() === "daily") {
                 buildFilePath(new Date(), dirPath);
                 folderHandling (folders, dirPath);


### PR DESCRIPTION
In windows, the app was throwing an error while calling auto-backup.
The issue was because of the folder name, windows don't allow `:` in folder names. Also, the initial auto-backup is set to `daily`. The issue is been fixed and tested.